### PR TITLE
Element ID's, fixed/added tooltips, and a fix for Duplicate File name error

### DIFF
--- a/scripts/wildcard_recursive.py
+++ b/scripts/wildcard_recursive.py
@@ -519,30 +519,41 @@ class Script(scripts.Script):
 
     def ui(self, is_img2img):
         self.is_txt2img = is_img2img == False
-        with gr.Accordion('UmiAI', open=True, elem_id="umiai"):
+        elemid_prefix = "img2img-umiai-" if is_img2img else "txt2img-umiai-"
+        with gr.Accordion('UmiAI', 
+                          open=True, 
+                          elem_id=elemid_prefix + "accordion"):
             with gr.Row():
-                enabled = gr.Checkbox(label="Enable UmiAI", value=True, elem_id="umiai-toggle")
+                enabled = gr.Checkbox(label="Enable UmiAI", 
+                                      value=True, 
+                                      elem_id=elemid_prefix + "toggle")
             with gr.Tab("Settings"):       
-                with gr.Row(elem_id="umiai-seeds"):
-                    shared_seed = gr.Checkbox(label="Static wildcards", value=False, 
-                                            elem_id="umiai-static-wildcards",
-                                            tooltip="Always picks the same random/wildcard options when using a static seed.")
-                    same_seed = gr.Checkbox(label='Same prompt in batch', value=False, 
-                                            elem_id="umiai-same-seed",
+                with gr.Row(elem_id=elemid_prefix + "seeds"):
+                    shared_seed = gr.Checkbox(label="Static wildcards", 
+                                              value=False, 
+                                              elem_id=elemid_prefix + "static-wildcards", 
+                                              tooltip="Always picks the same random/wildcard options when using a static seed.")
+                    same_seed = gr.Checkbox(label='Same prompt in batch', 
+                                            value=False, 
+                                            elem_id=elemid_prefix + "same-seed", 
                                             tooltip="Same prompt will be used for all generated images in a batch.")
-                with gr.Row(elem_id="umiai-lesser"):                
-                    cache_files = gr.Checkbox(label="Cache tag files", value=True,
-                                            elem_id="umiai-cache-files", 
-                                            tooltip="Cache .txt and .yaml files at runtime. Speeds up prompt generation. Disable if you're editing wildcard files to see changes instantly.")
-                    verbose = gr.Checkbox(label="Verbose logging", value=False, 
-                                            elem_id="umiai-verbose",
-                                            tooltip="Displays UmiAI log messages. Useful when prompt crafting, or debugging file-path errors.")
-                    negative_prompt = gr.Checkbox(label='**negative keywords**', value=True,
-                                            elem_id="umiai-negative-keywords", 
-                                            tooltip="Collect and add **negative keywords** from wildcards to Negative Prompts.")
-                    ignore_folders = gr.Checkbox(label="Ignore folders", value=False,
-                                            elem_id="umiai-ignore-folders",
-                                            tooltip="Ignore folder structure, will choose first file found if duplicate file names exist.")
+                with gr.Row(elem_id=elemid_prefix + "lesser"):                
+                    cache_files = gr.Checkbox(label="Cache tag files", 
+                                              value=True, 
+                                              elem_id=elemid_prefix + "cache-files", 
+                                              tooltip="Cache .txt and .yaml files at runtime. Speeds up prompt generation. Disable if you're editing wildcard files to see changes instantly.")
+                    verbose = gr.Checkbox(label="Verbose logging", 
+                                          value=False, 
+                                          elem_id=elemid_prefix + "verbose",
+                                          tooltip="Displays UmiAI log messages. Useful when prompt crafting, or debugging file-path errors.")
+                    negative_prompt = gr.Checkbox(label='**negative keywords**', 
+                                                  value=True,
+                                                  elem_id=elemid_prefix + "negative-keywords", 
+                                                  tooltip="Collect and add **negative keywords** from wildcards to Negative Prompts.")
+                    ignore_folders = gr.Checkbox(label="Ignore folders", 
+                                                 value=False,
+                                                 elem_id=elemid_prefix + "ignore-folders",
+                                                 tooltip="Ignore folder structure, will choose first file found if duplicate file names exist.")
                                             
             with gr.Tab("Usage"):
                 gr.Markdown(UsageGuide)

--- a/scripts/wildcard_recursive.py
+++ b/scripts/wildcard_recursive.py
@@ -105,7 +105,7 @@ class TagLoader:
         else:
             if (self.ignore_paths):
                 basename = os.path.basename(file_path.lower())
-            key = file_path.lower()
+            key = file_path
 
         if self.wildcard_location and os.path.isfile(txt_file_path):
             with open(txt_file_path, encoding="utf8") as file:

--- a/scripts/wildcard_recursive.py
+++ b/scripts/wildcard_recursive.py
@@ -524,19 +524,26 @@ class Script(scripts.Script):
                 enabled = gr.Checkbox(label="Enable UmiAI", value=True, elem_id="umiai-toggle")
             with gr.Tab("Settings"):       
                 with gr.Row(elem_id="umiai-seeds"):
-                    shared_seed = gr.Checkbox(label="Static wildcards", elem_id="umiai-static-wildcards", 
-                                                value=False, tooltip="Always picks the same random/wildcard options when using a static seed.")
+                    shared_seed = gr.Checkbox(label="Static wildcards", value=False, 
+                                            elem_id="umiai-static-wildcards",
+                                            tooltip="Always picks the same random/wildcard options when using a static seed.")
                     same_seed = gr.Checkbox(label='Same prompt in batch', value=False, 
+                                            elem_id="umiai-same-seed",
                                             tooltip="Same prompt will be used for all generated images in a batch.")
                 with gr.Row(elem_id="umiai-lesser"):                
-                    cache_files = gr.Checkbox(label="Cache tag files", value=True, 
+                    cache_files = gr.Checkbox(label="Cache tag files", value=True,
+                                            elem_id="umiai-cache-files", 
                                             tooltip="Cache .txt and .yaml files at runtime. Speeds up prompt generation. Disable if you're editing wildcard files to see changes instantly.")
                     verbose = gr.Checkbox(label="Verbose logging", value=False, 
-                                        tooltip="Displays UmiAI log messages. Useful when prompt crafting, or debugging file-path errors.")
+                                            elem_id="umiai-verbose",
+                                            tooltip="Displays UmiAI log messages. Useful when prompt crafting, or debugging file-path errors.")
                     negative_prompt = gr.Checkbox(label='**negative keywords**', value=True,
-                                                    elem_id="umiai-negative-keywords", 
-                                                    tooltip="Collect and add **negative keywords** from wildcards to Negative Prompts.")
-                    ignore_folders = gr.Checkbox(label="Ignore folders", value=False)
+                                            elem_id="umiai-negative-keywords", 
+                                            tooltip="Collect and add **negative keywords** from wildcards to Negative Prompts.")
+                    ignore_folders = gr.Checkbox(label="Ignore folders", value=False,
+                                            elem_id="umiai-ignore-folders",
+                                            tooltip="Ignore folder structure, will choose first file found if duplicate file names exist.")
+                                            
             with gr.Tab("Usage"):
                 gr.Markdown(UsageGuide)
 


### PR DESCRIPTION
"In the original code, the `key` variable is set to `file_path.lower()`, which converts the filename to lowercase. This lowercase version is then used as the key in the `loaded_tags` dictionary. However, when checking for duplicate filenames, the code uses the `basename` of the `file_path` (also converted to lowercase) to compare against the existing keys in the dictionary.

By changing the line to "key = file_path", the `loaded_tags` dictionary keys are now based on the original `file_path` values, which preserves the case sensitivity of the filenames. This ensures that the check for duplicate filenames correctly identifies duplicates based on the actual filenames, rather than just the lowercase versions." -PhindAI

Last two commits add/fix tooltips for ease of understanding and unique element ID's for both the text2img and img2img tabs so extensions like config-presets can latch on and control those items.